### PR TITLE
Flexible max-age cache-control

### DIFF
--- a/examples/in_memory/main.py
+++ b/examples/in_memory/main.py
@@ -42,13 +42,16 @@ async def get_date():
 async def get_datetime(request: Request, response: Response):
     return {"now": pendulum.now()}
 
+
 @cache(namespace="test")
 async def func_kwargs(*unused_args, **kwargs):
     return kwargs
 
+
 @app.get("/kwargs")
 async def get_kwargs(name: str):
     return await func_kwargs(name, name=name)
+
 
 @app.get("/sync-me")
 @cache(namespace="test")

--- a/fastapi_cache/backends/redis.py
+++ b/fastapi_cache/backends/redis.py
@@ -13,7 +13,7 @@ class RedisBackend(Backend):
 
     async def get_with_ttl(self, key: str) -> Tuple[int, str]:
         async with self.redis.pipeline(transaction=not self.is_cluster) as pipe:
-            return await (pipe.ttl(key).get(key).execute())
+            return await pipe.ttl(key).get(key).execute()
 
     async def get(self, key: str) -> Optional[str]:
         return await self.redis.get(key)

--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -137,7 +137,9 @@ def cache(
             try:
                 ttl, ret = await backend.get_with_ttl(cache_key)
             except Exception:
-                logger.warning(f"Error retrieving cache key '{cache_key}' from backend:", exc_info=True)
+                logger.warning(
+                    f"Error retrieving cache key '{cache_key}' from backend:", exc_info=True
+                )
                 ttl, ret = 0, None
             if not request:
                 if ret is not None:
@@ -146,14 +148,16 @@ def cache(
                 try:
                     await backend.set(cache_key, coder.encode(ret), expire)
                 except Exception:
-                    logger.warning(f"Error setting cache key '{cache_key}' in backend:", exc_info=True)
+                    logger.warning(
+                        f"Error setting cache key '{cache_key}' in backend:", exc_info=True
+                    )
                 return ret
 
             if request.method != "GET":
                 return await ensure_async_func(request, *args, **kwargs)
 
             if_none_match = request.headers.get("if-none-match")
-            
+
             cache_control_max_age = 0
             if client_max_age and isinstance(client_max_age, int):
                 cache_control_max_age = client_max_age

--- a/fastapi_cache/decorator.py
+++ b/fastapi_cache/decorator.py
@@ -182,7 +182,12 @@ def cache(
             except Exception:
                 logger.warning(f"Error setting cache key '{cache_key}' in backend:", exc_info=True)
 
-            response.headers["Cache-Control"] = f"max-age={expire}"
+            cache_control_max_age = 0
+            if client_max_age and isinstance(client_max_age, int):
+                cache_control_max_age = client_max_age
+            elif client_max_age and isinstance(client_max_age, str) and client_max_age == "ttl":
+                cache_control_max_age = expire
+            response.headers["Cache-Control"] = f"max-age={cache_control_max_age}"
             etag = f"W/{hash(encoded_ret)}"
             response.headers["ETag"] = etag
             return ret

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -37,7 +37,6 @@ def test_datetime() -> None:
 def test_date() -> None:
     """Test path function without request or response arguments."""
     with TestClient(app) as client:
-
         response = client.get("/date")
         assert pendulum.parse(response.json()) == pendulum.today()
 
@@ -68,8 +67,9 @@ def test_cache_response_obj() -> None:
         assert get_cache_response.headers.get("cache-control")
         assert get_cache_response.headers.get("etag")
 
+
 def test_kwargs() -> None:
     with TestClient(app) as client:
         name = "Jon"
-        response = client.get("/kwargs", params = {"name": name})
+        response = client.get("/kwargs", params={"name": name})
         assert response.json() == {"name": name}


### PR DESCRIPTION
Allow one more param (`client_max_age`) which can be an `int` or a `str`.

- If it is an `int` we use it as `max-age` on `cache-control` header
- If it is a `str` and is equals to `ttl` we use the ttl from the cache
- If it is different than both of other alternatives, we use 0 (no cache)